### PR TITLE
Fix #23 -- Correct int to decimal string conversion

### DIFF
--- a/sepaxml/utils.py
+++ b/sepaxml/utils.py
@@ -70,7 +70,7 @@ def int_to_decimal_str(integer):
     @return string The amount in currency with full stop decimal separator
     """
     int_string = str(integer)
-    if len(int_string) < 2:
+    if len(int_string) <= 2:
         return "0." + int_string.zfill(2)
     else:
         return int_string[:-2] + "." + int_string[-2:]


### PR DESCRIPTION
Currently, amounts with two digits are incorrectly converted, resulting
in amounts missing the leading '0'. This PR fixes that.