### PR TITLE
Support non-SEPA payments as well

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -78,6 +78,7 @@ Example:
         "IBAN": "NL50BANK1234567890",
         "BIC": "BANKNL2A",
         "batch": True,
+        # For non-SEPA transfers, set "domestic", necessary e.g. for CH/LI
         "currency": "EUR",  # ISO 4217
     }
     sepa = SepaTransfer(config, clean=True)
@@ -94,6 +95,7 @@ Example:
     sepa.add_payment(payment)
 
     print(sepa.export(validate=True))
+
 
 Development
 -----------

--- a/README.rst
+++ b/README.rst
@@ -78,7 +78,7 @@ Example:
         "IBAN": "NL50BANK1234567890",
         "BIC": "BANKNL2A",
         "batch": True,
-        # For non-SEPA transfers, set "domestic", necessary e.g. for CH/LI
+        # For non-SEPA transfers, set "domestic" to True, necessary e.g. for CH/LI
         "currency": "EUR",  # ISO 4217
     }
     sepa = SepaTransfer(config, clean=True)

--- a/sepaxml/transfer.py
+++ b/sepaxml/transfer.py
@@ -86,7 +86,7 @@ class SepaTransfer(SepaPaymentInitn):
             PmtInf_nodes['CtrlSumNode'].text = int_to_decimal_str(
                 payment['amount']
             )
-            if 'domestic' not in self._config:
+            if not self._config.get('domestic', False):
                 PmtInf_nodes['Cd_SvcLvl_Node'].text = "SEPA"
             if 'execution_date' in payment:
                 PmtInf_nodes['ReqdExctnDtNode'].text = payment['execution_date']
@@ -165,7 +165,7 @@ class SepaTransfer(SepaPaymentInitn):
         ED['NbOfTxsNode'] = ET.Element("NbOfTxs")
         ED['CtrlSumNode'] = ET.Element("CtrlSum")
         ED['PmtTpInfNode'] = ET.Element("PmtTpInf")
-        if 'domestic' not in self._config:
+        if not self._config.get('domestic', False):
             ED['SvcLvlNode'] = ET.Element("SvcLvl")
             ED['Cd_SvcLvl_Node'] = ET.Element("Cd")
         ED['ReqdExctnDtNode'] = ET.Element("ReqdExctnDt")
@@ -217,7 +217,7 @@ class SepaTransfer(SepaPaymentInitn):
         PmtInf_nodes['PmtInfNode'].append(PmtInf_nodes['NbOfTxsNode'])
         PmtInf_nodes['PmtInfNode'].append(PmtInf_nodes['CtrlSumNode'])
 
-        if 'domestic' not in self._config:
+        if not self._config.get('domestic', False):
             PmtInf_nodes['SvcLvlNode'].append(PmtInf_nodes['Cd_SvcLvl_Node'])
             PmtInf_nodes['PmtTpInfNode'].append(PmtInf_nodes['SvcLvlNode'])
             PmtInf_nodes['PmtInfNode'].append(PmtInf_nodes['PmtTpInfNode'])
@@ -322,7 +322,7 @@ class SepaTransfer(SepaPaymentInitn):
             PmtInf_nodes['PmtInfIdNode'].text = make_id(self._config['name'])
             PmtInf_nodes['PmtMtdNode'].text = "TRF"
             PmtInf_nodes['BtchBookgNode'].text = "true"
-            if 'domestic' not in self._config:
+            if not self._config.get('domestic', False):
                 PmtInf_nodes['Cd_SvcLvl_Node'].text = "SEPA"
 
             if batch_meta:
@@ -346,7 +346,7 @@ class SepaTransfer(SepaPaymentInitn):
             PmtInf_nodes['PmtInfNode'].append(PmtInf_nodes['NbOfTxsNode'])
             PmtInf_nodes['PmtInfNode'].append(PmtInf_nodes['CtrlSumNode'])
 
-            if 'domestic' not in self._config:
+            if not self._config.get('domestic', False):
                 PmtInf_nodes['SvcLvlNode'].append(PmtInf_nodes['Cd_SvcLvl_Node'])
                 PmtInf_nodes['PmtTpInfNode'].append(PmtInf_nodes['SvcLvlNode'])
                 PmtInf_nodes['PmtInfNode'].append(PmtInf_nodes['PmtTpInfNode'])

--- a/sepaxml/transfer.py
+++ b/sepaxml/transfer.py
@@ -86,7 +86,8 @@ class SepaTransfer(SepaPaymentInitn):
             PmtInf_nodes['CtrlSumNode'].text = int_to_decimal_str(
                 payment['amount']
             )
-            PmtInf_nodes['Cd_SvcLvl_Node'].text = "SEPA"
+            if 'domestic' not in self._config:
+                PmtInf_nodes['Cd_SvcLvl_Node'].text = "SEPA"
             if 'execution_date' in payment:
                 PmtInf_nodes['ReqdExctnDtNode'].text = payment['execution_date']
             else:
@@ -164,8 +165,9 @@ class SepaTransfer(SepaPaymentInitn):
         ED['NbOfTxsNode'] = ET.Element("NbOfTxs")
         ED['CtrlSumNode'] = ET.Element("CtrlSum")
         ED['PmtTpInfNode'] = ET.Element("PmtTpInf")
-        ED['SvcLvlNode'] = ET.Element("SvcLvl")
-        ED['Cd_SvcLvl_Node'] = ET.Element("Cd")
+        if 'domestic' not in self._config:
+            ED['SvcLvlNode'] = ET.Element("SvcLvl")
+            ED['Cd_SvcLvl_Node'] = ET.Element("Cd")
         ED['ReqdExctnDtNode'] = ET.Element("ReqdExctnDt")
 
         ED['DbtrNode'] = ET.Element("Dbtr")
@@ -215,9 +217,10 @@ class SepaTransfer(SepaPaymentInitn):
         PmtInf_nodes['PmtInfNode'].append(PmtInf_nodes['NbOfTxsNode'])
         PmtInf_nodes['PmtInfNode'].append(PmtInf_nodes['CtrlSumNode'])
 
-        PmtInf_nodes['SvcLvlNode'].append(PmtInf_nodes['Cd_SvcLvl_Node'])
-        PmtInf_nodes['PmtTpInfNode'].append(PmtInf_nodes['SvcLvlNode'])
-        PmtInf_nodes['PmtInfNode'].append(PmtInf_nodes['PmtTpInfNode'])
+        if 'domestic' not in self._config:
+            PmtInf_nodes['SvcLvlNode'].append(PmtInf_nodes['Cd_SvcLvl_Node'])
+            PmtInf_nodes['PmtTpInfNode'].append(PmtInf_nodes['SvcLvlNode'])
+            PmtInf_nodes['PmtInfNode'].append(PmtInf_nodes['PmtTpInfNode'])
         if 'ReqdExctnDtNode' in PmtInf_nodes:
             PmtInf_nodes['PmtInfNode'].append(PmtInf_nodes['ReqdExctnDtNode'])
 
@@ -319,7 +322,8 @@ class SepaTransfer(SepaPaymentInitn):
             PmtInf_nodes['PmtInfIdNode'].text = make_id(self._config['name'])
             PmtInf_nodes['PmtMtdNode'].text = "TRF"
             PmtInf_nodes['BtchBookgNode'].text = "true"
-            PmtInf_nodes['Cd_SvcLvl_Node'].text = "SEPA"
+            if 'domestic' not in self._config:
+                PmtInf_nodes['Cd_SvcLvl_Node'].text = "SEPA"
 
             if batch_meta:
                 PmtInf_nodes['ReqdExctnDtNode'].text = batch_meta
@@ -342,9 +346,10 @@ class SepaTransfer(SepaPaymentInitn):
             PmtInf_nodes['PmtInfNode'].append(PmtInf_nodes['NbOfTxsNode'])
             PmtInf_nodes['PmtInfNode'].append(PmtInf_nodes['CtrlSumNode'])
 
-            PmtInf_nodes['SvcLvlNode'].append(PmtInf_nodes['Cd_SvcLvl_Node'])
-            PmtInf_nodes['PmtTpInfNode'].append(PmtInf_nodes['SvcLvlNode'])
-            PmtInf_nodes['PmtInfNode'].append(PmtInf_nodes['PmtTpInfNode'])
+            if 'domestic' not in self._config:
+                PmtInf_nodes['SvcLvlNode'].append(PmtInf_nodes['Cd_SvcLvl_Node'])
+                PmtInf_nodes['PmtTpInfNode'].append(PmtInf_nodes['SvcLvlNode'])
+                PmtInf_nodes['PmtInfNode'].append(PmtInf_nodes['PmtTpInfNode'])
             if 'ReqdExctnDtNode' in PmtInf_nodes:
                 PmtInf_nodes['PmtInfNode'].append(PmtInf_nodes['ReqdExctnDtNode'])
 

--- a/tests/transfer/test_domestic.py
+++ b/tests/transfer/test_domestic.py
@@ -1,0 +1,121 @@
+import datetime
+
+import pytest
+
+from sepaxml import SepaTransfer
+from tests.utils import clean_ids, validate_xml
+
+
+@pytest.fixture
+def strf():
+    return SepaTransfer({
+        "name": "TestCreditor",
+        "IBAN": "CH4912345123456789012",
+        "batch": True,
+        "domestic": True,
+        "currency": "CHF"
+    }, schema="pain.001.001.03")
+
+
+SAMPLE_RESULT = b"""
+<Document xmlns="urn:iso:std:iso:20022:tech:xsd:pain.001.001.03" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <CstmrCdtTrfInitn>
+    <GrpHdr>
+      <MsgId>20180724040432-d24ce3b3e284</MsgId>
+      <CreDtTm>2018-07-24T16:04:32</CreDtTm>
+      <NbOfTxs>2</NbOfTxs>
+      <CtrlSum>60.12</CtrlSum>
+      <InitgPty>
+        <Nm>TestCreditor</Nm>
+      </InitgPty>
+    </GrpHdr>
+    <PmtInf>
+      <PmtInfId>TestCreditor-90102652f82a</PmtInfId>
+      <PmtMtd>TRF</PmtMtd>
+      <BtchBookg>true</BtchBookg>
+      <NbOfTxs>2</NbOfTxs>
+      <CtrlSum>60.12</CtrlSum>
+      <ReqdExctnDt>2018-07-24</ReqdExctnDt>
+      <Dbtr>
+        <Nm>TestCreditor</Nm>
+      </Dbtr>
+      <DbtrAcct>
+        <Id>
+          <IBAN>CH4912345123456789012</IBAN>
+        </Id>
+      </DbtrAcct>
+      <DbtrAgt>
+        <FinInstnId/>
+      </DbtrAgt>
+      <ChrgBr>SLEV</ChrgBr>
+      <CdtTrfTxInf>
+        <PmtId>
+          <EndToEndId>NOTPROVIDED</EndToEndId>
+        </PmtId>
+        <Amt>
+          <InstdAmt Ccy="CHF">10.12</InstdAmt>
+        </Amt>
+        <CdtrAgt>
+          <FinInstnId/>
+        </CdtrAgt>
+        <Cdtr>
+          <Nm>Test von Testenstein</Nm>
+        </Cdtr>
+        <CdtrAcct>
+          <Id>
+            <IBAN>CH4912345123456789012</IBAN>
+          </Id>
+        </CdtrAcct>
+        <RmtInf>
+          <Ustrd>Test transaction1</Ustrd>
+        </RmtInf>
+      </CdtTrfTxInf>
+      <CdtTrfTxInf>
+        <PmtId>
+          <EndToEndId>NOTPROVIDED</EndToEndId>
+        </PmtId>
+        <Amt>
+          <InstdAmt Ccy="CHF">50.00</InstdAmt>
+        </Amt>
+        <CdtrAgt>
+          <FinInstnId/>
+        </CdtrAgt>
+        <Cdtr>
+          <Nm>Test du Test</Nm>
+        </Cdtr>
+        <CdtrAcct>
+          <Id>
+            <IBAN>CH6911111222222222222</IBAN>
+          </Id>
+        </CdtrAcct>
+        <RmtInf>
+          <Ustrd>Test transaction2</Ustrd>
+        </RmtInf>
+      </CdtTrfTxInf>
+    </PmtInf>
+  </CstmrCdtTrfInitn>
+</Document>
+"""
+
+
+def test_two_domestic_debits(strf):
+    payment1 = {
+        "name": "Test von Testenstein",
+        "IBAN": "CH4912345123456789012",
+        "amount": 1012,
+        "execution_date": datetime.date.today(),
+        "description": "Test transaction1"
+    }
+    payment2 = {
+        "name": "Test du Test",
+        "IBAN": "CH6911111222222222222",
+        "amount": 5000,
+        "execution_date": datetime.date.today(),
+        "description": "Test transaction2"
+    }
+
+    strf.add_payment(payment1)
+    strf.add_payment(payment2)
+    xmlout = strf.export()
+    xmlpretty = validate_xml(xmlout, "pain.001.001.03")
+    assert clean_ids(xmlpretty.strip()) == clean_ids(SAMPLE_RESULT.strip())


### PR DESCRIPTION
Specifying `domestic` attribute will suppress elements for `SvcLvl` code "SEPA". This is necessary for transactions within CH/LI, where SEPA transfers are refused. This is weird, IMHO, but specified in the [Swiss Business Rules](https://www.paymentstandards.ch/de/shared/communication-grid/business-rules.html) and observed by banks.