### PR TITLE
Add the UltmtCdtr block for SEPA Direct Debit (Ultimate Creditor)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -57,6 +57,13 @@ Example:
             "country_subdivision": None,
             "lines": ["Line 1", "Line 2"],
         },
+        "ultimate_creditor": {
+            # The ultimate_creditor and all of its fields are optional but in some financial institution they are required
+            "name": "Real Creditor",
+            "BIC_or_BEI": "REALNL2A",
+            "id": "12345678900001", # can be a local official id or the creditor_id
+            "id_scheme_name": "SIRET", # proprietary scheme of the id provided (i.e. SEPA, SIRET...)
+        },
     }
     sepa = SepaDD(config, schema="pain.008.001.02", clean=True)
 

--- a/sepaxml/debit.py
+++ b/sepaxml/debit.py
@@ -215,6 +215,20 @@ class SepaDD(SepaPaymentInitn):
         else:
             ED['Othr_CdtrAgt_Node'] = ET.Element("Othr")
             ED['Id_CdtrAgt_Node'] = ET.Element("Id")
+        if 'ultimate_creditor' in self._config:
+            ED['UltmtCdtrNode'] = ET.Element("UltmtCdtr")
+            if 'name' in self._config['ultimate_creditor']:
+                ED['Nm_UltmtCdtr_Node'] = ET.Element("Nm")
+            ED['Id_UltmtCdtr_Node'] = ET.Element("Id")
+            ED['OrgId_Id_UltmtCdtr_Node'] = ET.Element("OrgId")
+            if 'BIC_or_BEI' in self._config['ultimate_creditor']:
+                ED['BICOrBEI_OrgId_Id_UltmtCdtr_Node'] = ET.Element("BICOrBEI")
+            if 'id' in self._config['ultimate_creditor']:
+                ED['Othr_OrgId_Id_UltmtCdtr_Node'] = ET.Element("Othr")
+                ED['Id_Othr_OrgId_Id_UltmtCdtr_Node'] = ET.Element("Id")
+                if 'id_scheme_name' in self._config['ultimate_creditor']:
+                    ED['SchmeNm_Othr_OrgId_Id_UltmtCdtr_Node'] = ET.Element("SchmeNm")
+                    ED['Prtry_SchmeNm_Othr_OrgId_Id_UltmtCdtr_Node'] = ET.Element("Prtry")
         ED['ChrgBrNode'] = ET.Element("ChrgBr")
         ED['CdtrSchmeIdNode'] = ET.Element("CdtrSchmeId")
         ED['Id_CdtrSchmeId_Node'] = ET.Element("Id")
@@ -445,6 +459,16 @@ class SepaDD(SepaPaymentInitn):
             PmtInf_nodes['NbOfTxsNode'].text = str(len(batch_nodes))
             PmtInf_nodes['CtrlSumNode'].text = int_to_decimal_str(self._batch_totals[batch_meta])
 
+            if 'ultimate_creditor' in self._config:
+                if 'name' in self._config['ultimate_creditor']:
+                    PmtInf_nodes['Nm_UltmtCdtr_Node'].text = self._config['ultimate_creditor']['name']
+                if 'BIC_or_BEI' in self._config['ultimate_creditor']:
+                    PmtInf_nodes['BICOrBEI_OrgId_Id_UltmtCdtr_Node'].text = self._config['ultimate_creditor']['BIC_or_BEI']
+                if 'id' in self._config['ultimate_creditor']:
+                    PmtInf_nodes['Id_Othr_OrgId_Id_UltmtCdtr_Node'].text = self._config['ultimate_creditor']['id']
+                if 'id_scheme_name' in self._config['ultimate_creditor']:
+                    PmtInf_nodes['Prtry_SchmeNm_Othr_OrgId_Id_UltmtCdtr_Node'].text = self._config['ultimate_creditor']['id_scheme_name']
+
             PmtInf_nodes['PmtInfNode'].append(PmtInf_nodes['PmtInfIdNode'])
             PmtInf_nodes['PmtInfNode'].append(PmtInf_nodes['PmtMtdNode'])
             PmtInf_nodes['PmtInfNode'].append(PmtInf_nodes['BtchBookgNode'])
@@ -483,6 +507,29 @@ class SepaDD(SepaPaymentInitn):
             PmtInf_nodes['CdtrAgtNode'].append(
                 PmtInf_nodes['FinInstnId_CdtrAgt_Node'])
             PmtInf_nodes['PmtInfNode'].append(PmtInf_nodes['CdtrAgtNode'])
+
+            if 'ultimate_creditor' in self._config:
+                if 'BIC_or_BEI' in self._config['ultimate_creditor']:
+                    PmtInf_nodes['OrgId_Id_UltmtCdtr_Node'].append(
+                        PmtInf_nodes['BICOrBEI_OrgId_Id_UltmtCdtr_Node'])
+                PmtInf_nodes['Id_UltmtCdtr_Node'].append(
+                    PmtInf_nodes['OrgId_Id_UltmtCdtr_Node'])
+                if 'id' in self._config['ultimate_creditor']:
+                    PmtInf_nodes['Othr_OrgId_Id_UltmtCdtr_Node'].append(
+                        PmtInf_nodes['Id_Othr_OrgId_Id_UltmtCdtr_Node'])
+                    if 'id_scheme_name' in self._config['ultimate_creditor']:
+                        PmtInf_nodes['SchmeNm_Othr_OrgId_Id_UltmtCdtr_Node'].append(
+                            PmtInf_nodes['Prtry_SchmeNm_Othr_OrgId_Id_UltmtCdtr_Node'])
+                        PmtInf_nodes['Othr_OrgId_Id_UltmtCdtr_Node'].append(
+                            PmtInf_nodes['SchmeNm_Othr_OrgId_Id_UltmtCdtr_Node'])
+                    PmtInf_nodes['OrgId_Id_UltmtCdtr_Node'].append(
+                        PmtInf_nodes['Othr_OrgId_Id_UltmtCdtr_Node'])
+                if 'name' in self._config['ultimate_creditor']:
+                    PmtInf_nodes['UltmtCdtrNode'].append(
+                        PmtInf_nodes['Nm_UltmtCdtr_Node'])
+                PmtInf_nodes['UltmtCdtrNode'].append(
+                    PmtInf_nodes['Id_UltmtCdtr_Node'])
+                PmtInf_nodes['PmtInfNode'].append(PmtInf_nodes['UltmtCdtrNode'])
 
             PmtInf_nodes['PmtInfNode'].append(PmtInf_nodes['ChrgBrNode'])
 


### PR DESCRIPTION
Add an optional Ultimate Creditor block for SEPA Direct Debit.

I have implemented it for Organization only (not individuals) following ISO 20022 ([french source](https://www.cfonb.org/sites/www.cfonb.org/files/documents/7.%20Guide%20d%27utilisation%20du%20standard%20ISO%2020022%20pour%20les%20remises%20d%27ordres%20de%20pr%C3%A9l%C3%A8vement%20SEPA%20pain%20008%20-%20V.1.6%20-%20Octobre%202021.pdf))