### PR TITLE
Add optional currency override

### DIFF
--- a/sepaxml/debit.py
+++ b/sepaxml/debit.py
@@ -130,7 +130,7 @@ class SepaDD(SepaPaymentInitn):
             bic = False
 
         TX_nodes = self._create_TX_node(bic)
-        TX_nodes['InstdAmtNode'].set("Ccy", self._config['currency'])
+        TX_nodes['InstdAmtNode'].set("Ccy", payment.get('currency', self._config['currency']))
         TX_nodes['InstdAmtNode'].text = int_to_decimal_str(payment['amount'])
 
         TX_nodes['MndtIdNode'].text = payment['mandate_id']

--- a/sepaxml/transfer.py
+++ b/sepaxml/transfer.py
@@ -137,7 +137,7 @@ class SepaTransfer(SepaPaymentInitn):
             bic = False
 
         TX_nodes = self._create_TX_node(bic)
-        TX_nodes['InstdAmtNode'].set("Ccy", self._config['currency'])
+        TX_nodes['InstdAmtNode'].set("Ccy", payment.get('currency', self._config['currency']))
         TX_nodes['InstdAmtNode'].text = int_to_decimal_str(payment['amount'])
         TX_nodes['EndToEnd_PmtId_Node'].text = payment.get('endtoend_id', 'NOTPROVIDED')
         if bic:

--- a/tests/debit/test_currency_override.py
+++ b/tests/debit/test_currency_override.py
@@ -1,0 +1,137 @@
+# encoding: utf-8
+
+import datetime
+
+import pytest
+
+from sepaxml import SepaDD
+from tests.utils import clean_ids, validate_xml
+
+
+
+@pytest.fixture
+def sdd():
+    return SepaDD({
+        "name": "Miller & Son Ltd",
+        "IBAN": "NL50BANK1234567890",
+        "BIC": "BANKNL2A",
+        "batch": True,
+        "creditor_id": "DE26ZZZ00000000000",
+        "currency": "EUR"
+    }, schema="pain.008.001.02")
+
+
+SAMPLE_RESULT = b"""
+<Document xmlns="urn:iso:std:iso:20022:tech:xsd:pain.008.001.02" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <CstmrDrctDbtInitn>
+    <GrpHdr>
+      <MsgId>20012017014921-ba2dab283fdd</MsgId>
+      <CreDtTm>2017-01-20T13:49:21</CreDtTm>
+      <NbOfTxs>1</NbOfTxs>
+      <CtrlSum>10.12</CtrlSum>
+      <InitgPty>
+        <Nm>Miller &amp; Son Ltd</Nm>
+        <Id>
+          <OrgId>
+            <Othr>
+              <Id>DE26ZZZ00000000000</Id>
+            </Othr>
+          </OrgId>
+        </Id>
+      </InitgPty>
+    </GrpHdr>
+    <PmtInf>
+      <PmtInfId>MillerSonLtd-ecd6a2f680ce</PmtInfId>
+      <PmtMtd>DD</PmtMtd>
+      <BtchBookg>true</BtchBookg>
+      <NbOfTxs>1</NbOfTxs>
+      <CtrlSum>10.12</CtrlSum>
+      <PmtTpInf>
+        <SvcLvl>
+          <Cd>SEPA</Cd>
+        </SvcLvl>
+        <LclInstrm>
+          <Cd>CORE</Cd>
+        </LclInstrm>
+        <SeqTp>FRST</SeqTp>
+      </PmtTpInf>
+      <ReqdColltnDt>2017-01-20</ReqdColltnDt>
+      <Cdtr>
+        <Nm>Miller &amp; Son Ltd</Nm>
+      </Cdtr>
+      <CdtrAcct>
+        <Id>
+          <IBAN>NL50BANK1234567890</IBAN>
+        </Id>
+      </CdtrAcct>
+      <CdtrAgt>
+        <FinInstnId>
+          <BIC>BANKNL2A</BIC>
+        </FinInstnId>
+      </CdtrAgt>
+      <ChrgBr>SLEV</ChrgBr>
+      <CdtrSchmeId>
+        <Id>
+          <PrvtId>
+            <Othr>
+              <Id>DE26ZZZ00000000000</Id>
+              <SchmeNm>
+                <Prtry>SEPA</Prtry>
+              </SchmeNm>
+            </Othr>
+          </PrvtId>
+        </Id>
+      </CdtrSchmeId>
+      <DrctDbtTxInf>
+        <PmtId>
+          <EndToEndId>MillerSonLtd-1234567890ab</EndToEndId>
+        </PmtId>
+        <InstdAmt Ccy="GBP">10.12</InstdAmt>
+        <DrctDbtTx>
+          <MndtRltdInf>
+            <MndtId>1234</MndtId>
+            <DtOfSgntr>2017-01-20</DtOfSgntr>
+          </MndtRltdInf>
+        </DrctDbtTx>
+        <DbtrAgt>
+          <FinInstnId>
+            <BIC>BANKNL2A</BIC>
+          </FinInstnId>
+        </DbtrAgt>
+        <Dbtr>
+          <Nm>This is a test</Nm>
+        </Dbtr>
+        <DbtrAcct>
+          <Id>
+            <IBAN>NL50BANK1234567890</IBAN>
+          </Id>
+        </DbtrAcct>
+        <RmtInf>
+          <Ustrd>Test transaction</Ustrd>
+        </RmtInf>
+      </DrctDbtTxInf>
+    </PmtInf>
+  </CstmrDrctDbtInitn>
+</Document>
+"""
+
+
+def test_payment_overrides_currency(sdd):
+    """Test that payment currency overrides config currency"""
+    payment = {
+        "name": "This is a test",
+        "IBAN": "NL50BANK1234567890",
+        "BIC": "BANKNL2A",
+        "amount": 1012,
+        "type": "FRST",
+        "collection_date": datetime.date.today(),
+        "mandate_id": "1234",
+        "mandate_date": datetime.date.today(),
+        "description": "Test transaction",
+        "currency": "GBP"  # Override the EUR config currency
+    }
+
+    sdd.add_payment(payment)
+    xmlout = sdd.export()
+    xmlpretty = validate_xml(xmlout, "pain.008.001.02")
+    assert clean_ids(xmlpretty.strip()) == clean_ids(SAMPLE_RESULT.strip())

--- a/tests/transfer/test_currency_override.py
+++ b/tests/transfer/test_currency_override.py
@@ -1,0 +1,106 @@
+# encoding: utf-8
+
+import datetime
+
+import pytest
+
+from sepaxml import SepaTransfer
+from tests.utils import clean_ids, validate_xml
+
+
+@pytest.fixture
+def strf_eur():
+    return SepaTransfer({
+        "name": "Miller & Son Ltd",
+        "IBAN": "NL50BANK1234567890",
+        "BIC": "BANKNL2A",
+        "batch": True,
+        "currency": "EUR"
+    }, schema="pain.001.001.03")
+
+
+SAMPLE_RESULT = b"""
+<Document xmlns="urn:iso:std:iso:20022:tech:xsd:pain.001.001.03" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <CstmrCdtTrfInitn>
+    <GrpHdr>
+      <MsgId>20180724041136-3b840ce62087</MsgId>
+      <CreDtTm>2018-07-24T16:11:36</CreDtTm>
+      <NbOfTxs>1</NbOfTxs>
+      <CtrlSum>10.12</CtrlSum>
+      <InitgPty>
+        <Nm>Miller &amp; Son Ltd</Nm>
+      </InitgPty>
+    </GrpHdr>
+    <PmtInf>
+      <PmtInfId>MillerSonLtd-67c22f433a9e</PmtInfId>
+      <PmtMtd>TRF</PmtMtd>
+      <BtchBookg>true</BtchBookg>
+      <NbOfTxs>1</NbOfTxs>
+      <CtrlSum>10.12</CtrlSum>
+      <PmtTpInf>
+        <SvcLvl>
+          <Cd>SEPA</Cd>
+        </SvcLvl>
+      </PmtTpInf>
+      <ReqdExctnDt>2018-07-24</ReqdExctnDt>
+      <Dbtr>
+        <Nm>Miller &amp; Son Ltd</Nm>
+      </Dbtr>
+      <DbtrAcct>
+        <Id>
+          <IBAN>NL50BANK1234567890</IBAN>
+        </Id>
+      </DbtrAcct>
+      <DbtrAgt>
+        <FinInstnId>
+          <BIC>BANKNL2A</BIC>
+        </FinInstnId>
+      </DbtrAgt>
+      <ChrgBr>SLEV</ChrgBr>
+      <CdtTrfTxInf>
+        <PmtId>
+          <EndToEndId>test123</EndToEndId>
+        </PmtId>
+        <Amt>
+          <InstdAmt Ccy="GBP">10.12</InstdAmt>
+        </Amt>
+        <CdtrAgt>
+          <FinInstnId>
+            <BIC>BANKNL2A</BIC>
+          </FinInstnId>
+        </CdtrAgt>
+        <Cdtr>
+          <Nm>This is a test</Nm>
+        </Cdtr>
+        <CdtrAcct>
+          <Id>
+            <IBAN>NL50BANK1234567890</IBAN>
+          </Id>
+        </CdtrAcct>
+        <RmtInf>
+          <Ustrd>Test transaction</Ustrd>
+        </RmtInf>
+      </CdtTrfTxInf>
+    </PmtInf>
+  </CstmrCdtTrfInitn>
+</Document>
+"""
+
+
+def test_payment_overrides_currency(strf_eur):
+    """Test that payment currency overrides config currency"""
+    payment = {
+        "name": "This is a test",
+        "IBAN": "NL50BANK1234567890", 
+        "BIC": "BANKNL2A",
+        "amount": 1012,
+        "execution_date": datetime.date.today(),
+        "description": "Test transaction",
+        "endtoend_id": "test123",
+        "currency": "GBP"  # Override the EUR config currency
+    }
+
+    strf_eur.add_payment(payment)
+    xmlout = strf_eur.export()
+    xmlpretty = validate_xml(xmlout, "pain.001.001.03")
+    assert clean_ids(xmlpretty.strip()) == clean_ids(SAMPLE_RESULT.strip())


### PR DESCRIPTION
- Allows a specific payment in a transfer / debit file to be denominated in a currency other than the config / bank account currency. 
- Testing and local bank upload validation was performed successfully. @raphaelm Willing to add documentation where / as needed.