### PR TITLE
Fix XML element truth value testing deprecation warnings

### DIFF
--- a/sepaxml/transfer.py
+++ b/sepaxml/transfer.py
@@ -296,7 +296,7 @@ class SepaTransfer(SepaPaymentInitn):
             TX_nodes['CdtTrfTxInfNode'].append(TX_nodes['CdtrAgtNode'])
 
         TX_nodes['CdtrNode'].append(TX_nodes['Nm_Cdtr_Node'])
-        if TX_nodes['PstlAdr_Cdtr_Node']:
+        if len(TX_nodes['PstlAdr_Cdtr_Node']) > 0:
             TX_nodes['CdtrNode'].append(TX_nodes['PstlAdr_Cdtr_Node'])
 
         TX_nodes['CdtTrfTxInfNode'].append(TX_nodes['CdtrNode'])
@@ -329,7 +329,7 @@ class SepaTransfer(SepaPaymentInitn):
             TX_nodes['CdtTrfTxInfNode'].append(TX_nodes['CdtrAgtNode'])
 
         TX_nodes['CdtrNode'].append(TX_nodes['Nm_Cdtr_Node'])
-        if TX_nodes['PstlAdr_Cdtr_Node']:
+        if len(TX_nodes['PstlAdr_Cdtr_Node']) > 0:
             TX_nodes['CdtrNode'].append(TX_nodes['PstlAdr_Cdtr_Node'])
         TX_nodes['CdtTrfTxInfNode'].append(TX_nodes['CdtrNode'])
 
@@ -415,7 +415,7 @@ class SepaTransfer(SepaPaymentInitn):
                 PmtInf_nodes['PmtInfNode'].append(PmtInf_nodes['ReqdExctnDtNode'])
 
             PmtInf_nodes['DbtrNode'].append(PmtInf_nodes['Nm_Dbtr_Node'])
-            if PmtInf_nodes['PstlAdr_Dbtr_Node']:
+            if len(PmtInf_nodes['PstlAdr_Dbtr_Node']) > 0:
                 PmtInf_nodes['DbtrNode'].append(PmtInf_nodes['PstlAdr_Dbtr_Node'])
             PmtInf_nodes['PmtInfNode'].append(PmtInf_nodes['DbtrNode'])
 


### PR DESCRIPTION
Replace implicit truth value testing of XML elements with explicit len() checks to avoid deprecation warnings in newer Python versions. XML elements will always return True in future versions when used in boolean context, but len() properly checks if they have child elements.

Fixes #69

🤖 Generated with [Claude Code](https://claude.ai/code)