### PR TITLE
Fix indentation when setting self.msg_id

### DIFF
--- a/sepaxml/shared.py
+++ b/sepaxml/shared.py
@@ -51,8 +51,8 @@ class SepaPaymentInitn:
 
                 self._config['name'] = unidecode(self._config['name'])[:70]
 
-                if self._config.get('msg_id'):
-                    self.msg_id = self._config['msg_id'][:35]
+            if self._config.get('msg_id'):
+                self.msg_id = self._config['msg_id'][:35]
 
         self._prepare_document()
         self._create_header()


### PR DESCRIPTION
Setting of `self.msg_id` from `config` should not depend on the argument `clean` being True.