### PR TITLE
fix: resolve deprecation warnings in tests and XML processing

### DIFF
--- a/sepaxml/debit.py
+++ b/sepaxml/debit.py
@@ -323,7 +323,7 @@ class SepaDD(SepaPaymentInitn):
         PmtInf_nodes['PmtInfNode'].append(PmtInf_nodes['ReqdColltnDtNode'])
 
         PmtInf_nodes['CdtrNode'].append(PmtInf_nodes['Nm_Cdtr_Node'])
-        if PmtInf_nodes['PstlAdr_Cdtr_Node']:
+        if len(PmtInf_nodes['PstlAdr_Cdtr_Node']):
             PmtInf_nodes['CdtrNode'].append(PmtInf_nodes['PstlAdr_Cdtr_Node'])
         PmtInf_nodes['PmtInfNode'].append(PmtInf_nodes['CdtrNode'])
 
@@ -378,7 +378,7 @@ class SepaDD(SepaPaymentInitn):
         TX_nodes['DrctDbtTxInfNode'].append(TX_nodes['DbtrAgtNode'])
 
         TX_nodes['DbtrNode'].append(TX_nodes['Nm_Dbtr_Node'])
-        if TX_nodes['PstlAdr_Dbtr_Node']:
+        if len(TX_nodes['PstlAdr_Dbtr_Node']):
             TX_nodes['DbtrNode'].append(TX_nodes['PstlAdr_Dbtr_Node'])
         TX_nodes['DrctDbtTxInfNode'].append(TX_nodes['DbtrNode'])
 
@@ -420,7 +420,7 @@ class SepaDD(SepaPaymentInitn):
         TX_nodes['DrctDbtTxInfNode'].append(TX_nodes['DbtrAgtNode'])
 
         TX_nodes['DbtrNode'].append(TX_nodes['Nm_Dbtr_Node'])
-        if TX_nodes['PstlAdr_Dbtr_Node']:
+        if len(TX_nodes['PstlAdr_Dbtr_Node']):
             TX_nodes['DbtrNode'].append(TX_nodes['PstlAdr_Dbtr_Node'])
         TX_nodes['DrctDbtTxInfNode'].append(TX_nodes['DbtrNode'])
 
@@ -520,7 +520,7 @@ class SepaDD(SepaPaymentInitn):
             PmtInf_nodes['PmtInfNode'].append(PmtInf_nodes['ReqdColltnDtNode'])
 
             PmtInf_nodes['CdtrNode'].append(PmtInf_nodes['Nm_Cdtr_Node'])
-            if PmtInf_nodes['PstlAdr_Cdtr_Node']:
+            if len(PmtInf_nodes['PstlAdr_Cdtr_Node']):
                 PmtInf_nodes['CdtrNode'].append(PmtInf_nodes['PstlAdr_Cdtr_Node'])
             PmtInf_nodes['PmtInfNode'].append(PmtInf_nodes['CdtrNode'])
 

--- a/tests/transfer/test_config.py
+++ b/tests/transfer/test_config.py
@@ -4,7 +4,7 @@ from sepaxml import SepaTransfer
 
 
 def test_valid_config():
-    return SepaTransfer({
+    SepaTransfer({
         "name": "TestCreditor",
         "IBAN": "NL50BANK1234567890",
         "BIC": "BANKNL2A",
@@ -15,7 +15,7 @@ def test_valid_config():
 
 def test_invalid_config():
     with pytest.raises(Exception):
-        return SepaTransfer({
+        SepaTransfer({
             "name": "TestCreditor",
             "BIC": "BANKNL2A",
             "batch": True,


### PR DESCRIPTION
- Fixed DeprecationWarning in sepaxml/debit.py by replacing implicit boolean checks on XML elements with explicit len() checks. Empty elements will evaluate to True in future Python versions.
- Fixed PytestReturnNotNoneWarning in tests/transfer/test_config.py by removing return statements from test functions.